### PR TITLE
Add a URL scheme requirement

### DIFF
--- a/draft-vvv-webtransport-http3.md
+++ b/draft-vvv-webtransport-http3.md
@@ -152,7 +152,7 @@ After the session is established, the peers can exchange data in following ways:
 
 Http3Transport is terminated when the corresponding CONNECT stream is closed.
 
-# Session IDs {#session-ids}
+# Session IDs  {#session-ids}
 
 In order to allow multiple Http3Transport sessions to occur within the same
 HTTP/3 connection, Http3Transport assigns every session a unique ID, further
@@ -195,8 +195,8 @@ parameter implies that a peer understands extended CONNECT.
 
 ## Creating a New Session
 
-As Http3Transport sessions are established over HTTP, they are identified using
-the `https` URI scheme {{!RFC7230}}.
+As Http3Transport sessions are established over HTTP/3, they are identified
+using the `https` URI scheme {{!RFC7230}}.
 
 In order to create a new Http3Transport session, a client can send an HTTP
 CONNECT request.  The `:protocol` pseudo-header field MUST be set to

--- a/draft-vvv-webtransport-http3.md
+++ b/draft-vvv-webtransport-http3.md
@@ -195,6 +195,9 @@ parameter implies that a peer understands extended CONNECT.
 
 ## Creating a New Session
 
+As Http3Transport sessions are established over HTTP, they are identified using
+the `https` URI scheme {{!RFC7230}}.
+
 In order to create a new Http3Transport session, a client can send an HTTP
 CONNECT request.  The `:protocol` pseudo-header field MUST be set to
 `webtransport`.  The `:scheme` field MUST be `https`.  Both the `:authority` and

--- a/draft-vvv-webtransport-overview.md
+++ b/draft-vvv-webtransport-overview.md
@@ -18,6 +18,14 @@ author:
     organization: Google
     email: vasilvv@google.com
 
+informative:
+  CSP:
+    target: https://www.w3.org/TR/CSP/
+    title: "Content Security Policy Level 3"
+    author:
+      org: W3C
+    date: Working Draft
+
 --- abstract
 
 The WebTransport Protocol Framework enables clients constrained by the Web
@@ -188,6 +196,11 @@ sessions to the network endpoints that are not WebTransport servers.
 
 Any transport protocol used MUST provide a way for the server to filter the
 clients that can access it by the origin {{!RFC6454}}.
+
+Any transprot protocol used MUST provide a way for a server endpoint location to
+be described using a URI {{!RFC3986}}.  They can be used for integration with
+various Web platform features that represent resources as URIs, such as Content
+Security Policy [CSP].
 
 # Session Establishment
 

--- a/draft-vvv-webtransport-overview.md
+++ b/draft-vvv-webtransport-overview.md
@@ -108,7 +108,7 @@ Transport:
 
 Transport protocol:
 
-:  A transport protocol (WebTransprot protocol in context where this might be
+:  A transport protocol (WebTransport protocol in context where this might be
    ambiguos) is a protocol that can be used to back a transport on the wire.  It
    can provide the transport features described in this document, and is
    expected to fulfill all of the requirements described herein.
@@ -197,7 +197,7 @@ sessions to the network endpoints that are not WebTransport servers.
 Any transport protocol used MUST provide a way for the server to filter the
 clients that can access it by the origin {{!RFC6454}}.
 
-Any transprot protocol used MUST provide a way for a server endpoint location to
+Any transport protocol used MUST provide a way for a server endpoint location to
 be described using a URI {{!RFC3986}}.  They can be used for integration with
 various Web platform features that represent resources as URIs, such as Content
 Security Policy [CSP].

--- a/draft-vvv-webtransport-quic.md
+++ b/draft-vvv-webtransport-quic.md
@@ -248,6 +248,7 @@ adopted from {{!RFC3986}}.  The syntax of a QuicTransport URI SHALL be:
 ~~~~~~~~~~~~~~~
 quic-transport-URI = "quic-transport:" "//"
                              host [ ":" port ]
+                             path-abempty
                              [ "?" query ]
                              [ "#" fragment ]
 ~~~~~~~~~~~~~~~
@@ -260,14 +261,14 @@ specification assigns semantics to those.
 The `host` component MUST NOT be empty.  If the `port` component is missing, the
 port SHALL be assumed to be 0.
 
+NOTE: this effectively requires the port number to be specified.  This
+specification may include an actually usable default port number in the future.
+At this point, we are unable to provide such until IANA allocates one.
+
 In order to connect to a QuicTransport server identified by a given URI, the
 user agent SHALL establish a QUIC connection to the specified `host` and `port`
 as described in {{connection}}.  It MUST immediately signal an error to the user
 if the port value is 0.
-
-NOTE: this effectively requires the port number to be specified.  This
-specification may include an actually usable default port number in the future.
-At this point, we are unable to provide such until IANA allocates one.
 
 # Transport Properties
 

--- a/draft-vvv-webtransport-quic.md
+++ b/draft-vvv-webtransport-quic.md
@@ -233,12 +233,12 @@ datagram ID SHALL be absent.
 
 The datagrams sent using QuicTransport MUST be subject to congestion control.
 
-# QuicTransport URI Scheme {#uri}
+# QuicTransport URI Scheme  {#uri}
 
 NOTE: the URI scheme defintion in this section is provisional and subject to
 change, especially the name of the scheme.
 
-QuicTransport uses `quic-transport` URI scheme for identifying QuicTransport
+QuicTransport uses the `quic-transport` URI scheme for identifying QuicTransport
 servers.
 
 The syntax definition below uses Augmented Backus-Naur Form (ABNF) {{!RFC5234}}.
@@ -253,7 +253,7 @@ quic-transport-URI = "quic-transport:" "//"
                              [ "#" fragment ]
 ~~~~~~~~~~~~~~~
 
-This document does not define any semantics to `path-abemtpy`, `query` or
+This document does not define any semantics to `path-abempty`, `query` or
 `fragment` portions of the URI, nor does it delegate those to the host owners.
 Any QuicTransport implementation MUST ignore those until a subsequent
 specification assigns semantics to those.
@@ -263,12 +263,11 @@ port SHALL be assumed to be 0.
 
 NOTE: this effectively requires the port number to be specified.  This
 specification may include an actually usable default port number in the future.
-At this point, we are unable to provide such until IANA allocates one.
 
 In order to connect to a QuicTransport server identified by a given URI, the
 user agent SHALL establish a QUIC connection to the specified `host` and `port`
-as described in {{connection}}.  It MUST immediately signal an error to the user
-if the port value is 0.
+as described in {{connection}}.  It MUST immediately signal an error to the
+client if the port value is 0.
 
 # Transport Properties
 

--- a/draft-vvv-webtransport-quic.md
+++ b/draft-vvv-webtransport-quic.md
@@ -127,7 +127,7 @@ WebTransport streams are provided by creating an individual unidirectional or
 bidirectional QUIC stream.  WebTransport datagrams are provided through the QUIC
 datagram extension [QUIC-DATAGRAM].
 
-# Connection Establishment
+# Connection Establishment  {#connection}
 
 In order to establish a QuicTransport session, a QUIC connection must be
 established.  From the client perspective, the session becomes established when
@@ -233,6 +233,42 @@ datagram ID SHALL be absent.
 
 The datagrams sent using QuicTransport MUST be subject to congestion control.
 
+# QuicTransport URI Scheme {#uri}
+
+NOTE: the URI scheme defintion in this section is provisional and subject to
+change, especially the name of the scheme.
+
+QuicTransport uses `quic-transport` URI scheme for identifying QuicTransport
+servers.
+
+The syntax definition below uses Augmented Backus-Naur Form (ABNF) {{!RFC5234}}.
+The definitions of `host`, `port`, `path-abempty`, `query` and `fragment` are
+adopted from {{!RFC3986}}.  The syntax of a QuicTransport URI SHALL be:
+
+~~~~~~~~~~~~~~~
+quic-transport-URI = "quic-transport:" "//"
+                             host [ ":" port ]
+                             [ "?" query ]
+                             [ "#" fragment ]
+~~~~~~~~~~~~~~~
+
+This document does not define any semantics to `path-abemtpy`, `query` or
+`fragment` portions of the URI, nor does it delegate those to the host owners.
+Any QuicTransport implementation MUST ignore those until a subsequent
+specification assigns semantics to those.
+
+The `host` component MUST NOT be empty.  If the `port` component is missing, the
+port SHALL be assumed to be 0.
+
+In order to connect to a QuicTransport server identified by a given URI, the
+user agent SHALL establish a QUIC connection to the specified `host` and `port`
+as described in {{connection}}.  It MUST immediately signal an error to the user
+if the port value is 0.
+
+NOTE: this effectively requires the port number to be specified.  This
+specification may include an actually usable default port number in the future.
+At this point, we are unable to provide such until IANA allocates one.
+
 # Transport Properties
 
 QuicTransport supports most of WebTransport features as described in
@@ -332,5 +368,28 @@ Every entry in the registry SHALL include the following fields:
 The IANA policy, as descrbied in {{!RFC8126}}, SHALL be Standards Action for
 values between 0x0000 and 0x03ff; Specification Required for values between
 0x0400 and 0xefff; and Private Use for values between 0xf000 and 0xffff.
+
+## URI Scheme Registration
+
+This document contains the request for the registration of the URI scheme
+`quic-transport`.  The registration request is in accordance with {{!RFC7595}}.
+
+  Scheme name:
+  : quic-transport
+
+  Status:
+  : Permanent
+
+  Applications/protocols that use this scheme name:
+  : QuicTransport
+
+  Contact:
+  : IETF Chair <chair@ietf.org>
+
+  Change controller:
+  : IESG <iesg@ietf.org>
+
+  Reference:
+  : {{uri}} of this document.
 
 --- back


### PR DESCRIPTION
This defines a new URL scheme for QuicTransport, and clarifies the use
of "https" for Http3Transport.