### PR TITLE
Update WebTransport over HTTP/3 to be more in sync with HTTP/2

### DIFF
--- a/draft-vvv-webtransport-http3.md
+++ b/draft-vvv-webtransport-http3.md
@@ -172,8 +172,8 @@ MUST send a SETTINGS_ENABLE_WEBTRANSPORT value set to "1" in their SETTINGS
 frame.  Endpoints MUST NOT use any WebTransport-related functionality unless
 the parameter has been negotiated.
 
-If SETTINGS_ENABLE_WEBTRANSPORT is negotiated, support for the QUIC DATAGRAM
-extension MUST be negotiated as described in
+If SETTINGS_ENABLE_WEBTRANSPORT is negotiated, support for the QUIC DATAGRAMs
+within HTTP/3 MUST be negotiated as described in
 {{!HTTP3-DATAGRAM=I-D.schinazi-quic-h3-datagram}}; negotiating WebTransport
 support without negotiating QUIC DATAGRAM extension SHALL result in a
 H3_SETTINGS_ERROR error.

--- a/draft-vvv-webtransport-http3.md
+++ b/draft-vvv-webtransport-http3.md
@@ -413,7 +413,7 @@ Setting Name:
 
 Value:
 
-: 0x???? (currently H2 draft uses 0xFB)
+: 0x63e941ac
 
 Default:
 

--- a/draft-vvv-webtransport-http3.md
+++ b/draft-vvv-webtransport-http3.md
@@ -413,7 +413,7 @@ Setting Name:
 
 Value:
 
-: 0x63e941ac
+: 0x2b603742
 
 Default:
 

--- a/draft-vvv-webtransport-http3.md
+++ b/draft-vvv-webtransport-http3.md
@@ -138,7 +138,7 @@ WebTransport servers in general are identified by a pair of authority value and
 path value (defined in {{!RFC3986}} Sections 3.2 and 3.3 correspondingly).
 
 When an HTTP/3 connection is established, both the client and server have to
-negotiate a SETTINGS_ENABLE_WEBTRANSPORT setting in order to indicate that they
+send a SETTINGS_ENABLE_WEBTRANSPORT setting in order to indicate that they
 both support WebTransport over HTTP/3.
 
 WebTransport sessions are initiated inside a given HTTP/3 connection by the


### PR DESCRIPTION
This replaces a distinct Session ID mechanism with using stream ID of
the CONNECT stream as a Session ID.

The transport parameter used to opt into WebTransport is replaced with
a SETTINGS value.